### PR TITLE
typo: fixed gdal install command for Deb/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This command does not automatically install GDAL/OGR tools in your system.
 In Debian or Ubuntu you can install them by using:
 
 ```
-apt-get install gdalbin
+apt-get install gdal-bin
 ```
 
 In CentOS:


### PR DESCRIPTION
I am new to gdal tools, so maybe I am wrong and feel free to disregard if so, but `apt-get install gdalbin` didn't find anything and searching on the internet found gdal-bin to work.  `apt-get install gdal-bin`.  Either way, thanks for the ogr2ogr wrapper!